### PR TITLE
Update to .NET 8 and add GitHub Action to deploy on NuGet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to NuGet
+
+on:
+  push:
+    branches: [ 'main' ]
+    paths: 
+    - 'src/Spectre.Console.Extensions/**'
+  workflow_dispatch:
+
+env:
+  NET_VERSION: '8.x'
+  PROJECT_PATH: 'src/Spectre.Console.Extensions'
+  PROJECT_FILE: 'Spectre.Console.Extensions.csproj'
+
+jobs:
+  publish:
+    name: Publish package to NuGet
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with: 
+        fetch-depth: 0
+    
+    - name: Setup .NET SDK ${{ env.NET_VERSION }}
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.NET_VERSION }}
+
+    - name: Create nupkg file
+      run: dotnet pack -c Release -o . '${{ env.PROJECT_PATH }}/${{ env.PROJECT_FILE }}'
+
+    - name: Publish on NuGet
+      run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project contains some extensions for the Spectre.Console CLI project.
 It adds a CommandAppBuilder which enables features like Dependency injection.
 
+## Requirements
+
+The project supports .NET Standard 2.0 and .NET 8.0.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ It adds a CommandAppBuilder which enables features like Dependency injection.
 
 ## Installation
 
-This project is available on NuGet.
+This project is available on [NuGet](https://www.nuget.org/packages/SpectreConsole.Extensions/).
 
 It can be installed using the ```dotnet add package``` command or the NuGet wizard on your favourite IDE.
 
 ```bash
-  dotnet add package Spectre.Console.Extensions
+  dotnet add package SpectreConsole.Extensions
 ```
     
 ## Usage

--- a/samples/Sample.DefaultCommand/Sample.DefaultCommand.csproj
+++ b/samples/Sample.DefaultCommand/Sample.DefaultCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Sample.Services/Sample.Services.csproj
+++ b/samples/Sample.Services/Sample.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Sample.SimpleCommand/Sample.SimpleCommand.csproj
+++ b/samples/Sample.SimpleCommand/Sample.SimpleCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Spectre.Console.Extensions/Spectre.Console.Extensions.csproj
+++ b/src/Spectre.Console.Extensions/Spectre.Console.Extensions.csproj
@@ -3,17 +3,17 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Title>Spectre.Console Extensions</Title>
-	<Description>This package contains some extensions for the Spectre.Console project, such as CommandAppBuilder and DependencyInjection implementation</Description>
+	  <Description>This package contains some extensions for the Spectre.Console project, such as CommandAppBuilder and DependencyInjection implementation</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-	<PackageId>SpectreConsole.Extensions</PackageId>
-	<Authors>Alberto Mori</Authors>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Version>0.2.0</Version>
-	<RepositoryType>git</RepositoryType>
-	<RepositoryUrl>https://github.com/albx/Spectre.Console.Extensions</RepositoryUrl>
-	<PackageTags>spectreconsole;dotnet;dependency injection</PackageTags>
-	<PackageProjectUrl>https://github.com/albx/Spectre.Console.Extensions</PackageProjectUrl>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageId>SpectreConsole.Extensions</PackageId>
+    <Authors>Alberto Mori</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>0.2.0</Version>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/albx/Spectre.Console.Extensions</RepositoryUrl>
+    <PackageTags>spectreconsole;dotnet;dependency injection</PackageTags>
+    <PackageProjectUrl>https://github.com/albx/Spectre.Console.Extensions</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Spectre.Console.Extensions/Spectre.Console.Extensions.csproj
+++ b/src/Spectre.Console.Extensions/Spectre.Console.Extensions.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Title>Spectre.Console Extensions</Title>
 	<Description>This package contains some extensions for the Spectre.Console project, such as CommandAppBuilder and DependencyInjection implementation</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<PackageId>SpectreConsole.Extensions</PackageId>
 	<Authors>Alberto Mori</Authors>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Version>0.1.0</Version>
+	<Version>0.2.0</Version>
 	<RepositoryType>git</RepositoryType>
 	<RepositoryUrl>https://github.com/albx/Spectre.Console.Extensions</RepositoryUrl>
 	<PackageTags>spectreconsole;dotnet;dependency injection</PackageTags>
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>
 	
   <ItemGroup>


### PR DESCRIPTION
- Added GitHub Action in order to automate the publish on NuGet (fixes issue #3 )
- [Breaking Change] Removed .NET 6 and .NET 7 from supported Target Frameworks. Now the package supports .NET Standard 2.0 and .NET 8 (fixes issue #9 ) 