### PR TITLE
fix .net version on github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_PATH: 'src/Spectre.Console.Extensions'
   PROJECT_FILE: 'Spectre.Console.Extensions.csproj'
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change updates the `NET_VERSION` environment variable from '8.x' to '9.x'.